### PR TITLE
Remove guard enforcement

### DIFF
--- a/pact/hyp-erc20/hyp-erc20.pact
+++ b/pact/hyp-erc20/hyp-erc20.pact
@@ -284,7 +284,6 @@
   )
 
   (defun create-account:string (account:string guard:guard)
-    (enforce-guard guard)
     (enforce (validate-principal guard account)
       "Non-principal account names unsupported")
 

--- a/pact/syn-template.pact
+++ b/pact/syn-template.pact
@@ -284,7 +284,6 @@
   )
 
   (defun create-account:string (account:string guard:guard)
-    (enforce-guard guard)
     (enforce (validate-principal guard account)
       "Non-principal account names unsupported")
 


### PR DESCRIPTION
This results in account creation failing for things like create-pair on dexs.  It doesn't serve any specific purpose as we already validate principal and will lead to similar issues down the road.