### PR TITLE
Proposed changes

### DIFF
--- a/pact/col-template.pact
+++ b/pact/col-template.pact
@@ -280,6 +280,7 @@
 
   (defun transfer-create:string (sender:string receiver:string receiver-guard:guard amount:decimal)
     @model [ (property (= 0.0 (column-delta accounts "balance"))) ]
+    (enforce-reserved receiver receiver-guard)
 
     (with-capability (TRANSFER sender receiver amount)
       (with-read accounts sender { "balance" := sender-balance }
@@ -315,9 +316,17 @@
     (enforce (= amount (floor amount (precision))) "Amounts cannot exceed precision.")
   )
 
+  (defun enforce-reserved:bool (account:string guard:guard)
+    "Enforce that a principal account matches to it's guard"
+    (if (is-principal account)
+      (enforce (validate-principal guard account)
+                (format "Reserved protocol guard violation: {}" [(typeof-principal account)]))
+      true)
+  )
+
   (defun create-account:string (account:string guard:guard)
-    (enforce (validate-principal guard account)
-      "Non-principal account names unsupported")
+    (enforce-reserved account guard)
+
     (with-read contract-state "default"
       {
         "token" := token:module{fungible-v2, fungible-xchain-v1}

--- a/pact/hyp-erc20-collateral/hyp-erc20-collateral.pact
+++ b/pact/hyp-erc20-collateral/hyp-erc20-collateral.pact
@@ -280,6 +280,7 @@
 
   (defun transfer-create:string (sender:string receiver:string receiver-guard:guard amount:decimal)
     @model [ (property (= 0.0 (column-delta accounts "balance"))) ]
+    (enforce-reserved receiver receiver-guard)
 
     (with-capability (TRANSFER sender receiver amount)
       (with-read accounts sender { "balance" := sender-balance }
@@ -315,9 +316,17 @@
     (enforce (= amount (floor amount (precision))) "Amounts cannot exceed precision.")
   )
 
+  (defun enforce-reserved:bool (account:string guard:guard)
+    "Enforce that a principal account matches to it's guard"
+    (if (is-principal account)
+      (enforce (validate-principal guard account)
+                (format "Reserved protocol guard violation: {}" [(typeof-principal account)]))
+      true)
+  )
+
   (defun create-account:string (account:string guard:guard)
-    (enforce (validate-principal guard account)
-      "Non-principal account names unsupported")
+    (enforce-reserved account guard)
+
     (with-read contract-state "default"
       {
         "token" := token:module{fungible-v2, fungible-xchain-v1}

--- a/pact/hyp-erc20/hyp-erc20.pact
+++ b/pact/hyp-erc20/hyp-erc20.pact
@@ -249,6 +249,7 @@
 
   (defun transfer-create:string (sender:string receiver:string receiver-guard:guard amount:decimal)
     @model [ (property (= 0.0 (column-delta accounts "balance"))) ]
+    (enforce-reserved receiver receiver-guard)
 
     (with-capability (TRANSFER sender receiver amount)
       (with-read accounts sender { "balance" := sender-balance }
@@ -283,9 +284,16 @@
     (enforce (= amount (floor amount (precision))) "Amounts cannot exceed precision.")
   )
 
+  (defun enforce-reserved:bool (account:string guard:guard)
+  "Enforce that a principal account matches to it's guard"
+  (if (is-principal account)
+      (enforce (validate-principal guard account)
+                (format "Reserved protocol guard violation: {}" [(typeof-principal account)]))
+      true)
+  )
+
   (defun create-account:string (account:string guard:guard)
-    (enforce (validate-principal guard account)
-      "Non-principal account names unsupported")
+    (enforce-reserved account guard)
 
     (insert accounts account
       { "account": account

--- a/pact/syn-template.pact
+++ b/pact/syn-template.pact
@@ -249,6 +249,7 @@
 
   (defun transfer-create:string (sender:string receiver:string receiver-guard:guard amount:decimal)
     @model [ (property (= 0.0 (column-delta accounts "balance"))) ]
+    (enforce-reserved receiver receiver-guard)
 
     (with-capability (TRANSFER sender receiver amount)
       (with-read accounts sender { "balance" := sender-balance }
@@ -283,9 +284,16 @@
     (enforce (= amount (floor amount (precision))) "Amounts cannot exceed precision.")
   )
 
+  (defun enforce-reserved:bool (account:string guard:guard)
+    "Enforce that a principal account matches to it's guard"
+    (if (is-principal account)
+      (enforce (validate-principal guard account)
+                (format "Reserved protocol guard violation: {}" [(typeof-principal account)]))
+      true)
+  )
+
   (defun create-account:string (account:string guard:guard)
-    (enforce (validate-principal guard account)
-      "Non-principal account names unsupported")
+    (enforce-reserved account guard)
 
     (insert accounts account
       { "account": account


### PR DESCRIPTION
We can't enforce principal like this on create-account, but we should do it for actual principal accounts.  The reason is dexs need multiple accounts on init for new pools, and this unfortunately is still too restrictive.